### PR TITLE
Create initial CI configuration with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: Build
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: cd samples && mkdir build
+      - run: cmake ..
+        working-directory: samples/build
+      - run: cmake --build .
+        working-directory: samples/build


### PR DESCRIPTION
Adds a simple CI configuration using GitHub Actions. It builds the samples on each push, pull request and when requested (workflow_dispatch), using CMake and MSVC.

An example run can be [found here](https://github.com/EwoutH/NVIDIAImageScaling/runs/4228385209?check_suite_focus=true).